### PR TITLE
Use generic ID type

### DIFF
--- a/docs/app.ts
+++ b/docs/app.ts
@@ -5,7 +5,7 @@ const NUMBER_OF_RUNS_PER_TEST = 3;
 const START_MARKER = "runTest started";
 const END_MARKER = "runTest ended";
 
-function runTest(numberOfItems: number, action: Action) {
+function runTest(numberOfItems: number, action: Action<string>) {
   const items: OrderedItem[] = [];
 
   for (var i = 0; i < numberOfItems; i++) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reorder-items",
-  "version": "0.1.3",
+  "version": "0.9",
   "description": "",
   "main": "build/cjs/reorder.js",
   "module": "build/esm/reorder.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build/"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --watch --coverage",
     "build": "tsc && yarn tsc -p tsconfig-cjs.json",
     "docs-server": "http-server ./docs-build",
     "docs-build": "yarn docs-build-prep && yarn tsc -p docs/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reorder-items",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "main": "build/cjs/reorder.js",
   "module": "build/esm/reorder.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build/"
   ],
   "scripts": {
-    "test": "jest --watch --coverage",
+    "test": "jest",
+    "coverage": "jest --watch --coverage",
     "build": "tsc && yarn tsc -p tsconfig-cjs.json",
     "docs-server": "http-server ./docs-build",
     "docs-build": "yarn docs-build-prep && yarn tsc -p docs/tsconfig.json",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,0 @@
-import { reorder } from "./reorder";
-
-const oldItems = [{ id: 123, order: 1 }];
-
-const { instructions, items } = reorder(oldItems, {
-  type: "REMOVE",
-  id: 123,
-});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,8 @@
+import { reorder } from "./reorder";
+
+const oldItems = [{ id: 123, order: 1 }];
+
+const { instructions, items } = reorder(oldItems, {
+  type: "REMOVE",
+  id: 123,
+});

--- a/src/reorder.test.ts
+++ b/src/reorder.test.ts
@@ -1,5 +1,11 @@
 import { reorder } from "./reorder";
-import { IdItem, Instructions, OrderedItem } from "./reorder.types";
+import {
+  IdItem,
+  InsertInstruction,
+  Instructions,
+  OrderedItem,
+  RemoveInstruction,
+} from "./reorder.types";
 const orderBy = require("lodash.orderby");
 
 const orderById = <T>(items: T[]): T[] => orderBy(items, ["id"]);
@@ -310,38 +316,64 @@ describe("Operations on items without 'column' property", () => {
     });
 
     it("returns values with string IDs when given an array with string IDs", () => {
-      const { items: newItems, instructions } = reorder([items[0]], {
+      const { items: newItems, instructions } = reorder(items, {
         type: "INSERT",
         item: newItem,
         order: 1,
       });
 
       // Test returned items
-      expect(typeof newItems[0].id).toEqual("string");
+      expect(newItems.map((item) => typeof item.id)).toEqual([
+        "string",
+        "string",
+        "string",
+        "string",
+      ]);
 
       // Test returned instructions
       expect(
-        instructions[0].type === "INSERT" && typeof instructions[0].item.id
-      ).toEqual("string");
+        instructions.map((instruction) => {
+          if (instruction.type === "INSERT") {
+            return typeof instruction.item.id;
+          } else if (instruction.type === "UPDATE") {
+            return typeof instruction.id;
+          }
+        })
+      ).toEqual(["string", "string", "string"]);
     });
 
     it("returns values with numeric IDs when given an array with numeric IDs", () => {
       const { items: newItems, instructions } = reorder(
-        [{ ...items[0], id: 123 }],
+        [
+          { ...items[0], id: 123 },
+          { ...items[1], id: 456 },
+          { ...items[2], id: 678 },
+        ],
         {
           type: "INSERT",
-          item: { ...newItem, id: 345 },
+          item: { ...newItem, id: 999 },
           order: 1,
         }
       );
 
       // Test returned items
-      expect(typeof newItems[0].id).toEqual("number");
+      expect(newItems.map((item) => typeof item.id)).toEqual([
+        "number",
+        "number",
+        "number",
+        "number",
+      ]);
 
       // Test returned instructions
       expect(
-        instructions[0].type === "INSERT" && typeof instructions[0].item.id
-      ).toEqual("number");
+        instructions.map((instruction) => {
+          if (instruction.type === "INSERT") {
+            return typeof instruction.item.id;
+          } else if (instruction.type === "UPDATE") {
+            return typeof instruction.id;
+          }
+        })
+      ).toEqual(["number", "number", "number"]);
     });
   });
 
@@ -461,8 +493,9 @@ describe("Operations on items without 'column' property", () => {
       // Test returned instructions
       expect(
         instructions.map(
-          (item) =>
-            (item.type === "REMOVE" || item.type === "UPDATE") && typeof item.id
+          (instruction) =>
+            (instruction.type === "REMOVE" || instruction.type === "UPDATE") &&
+            typeof instruction.id
         )
       ).toEqual(["string", "string", "string"]);
     });
@@ -487,8 +520,9 @@ describe("Operations on items without 'column' property", () => {
       // Test returned instructions
       expect(
         instructions.map(
-          (item) =>
-            (item.type === "REMOVE" || item.type === "UPDATE") && typeof item.id
+          (instruction) =>
+            (instruction.type === "REMOVE" || instruction.type === "UPDATE") &&
+            typeof instruction.id
         )
       ).toEqual(["number", "number", "number"]);
     });

--- a/src/reorder.test.ts
+++ b/src/reorder.test.ts
@@ -584,7 +584,6 @@ describe("Operations on items without 'column' property", () => {
           order: 1,
         }
       );
-      console.log(instructions);
 
       expect(typeof newItems[0].id).toEqual("number");
       expect(

--- a/src/reorder.test.ts
+++ b/src/reorder.test.ts
@@ -560,6 +560,38 @@ describe("Operations on items without 'column' property", () => {
       );
     });
   });
+
+  describe("Types", () => {
+    it("returns values with string IDs when given an array with string IDs", () => {
+      const { items: newItems, instructions } = reorder([items[0]], {
+        type: "INSERT",
+        item: newItem,
+        order: 1,
+      });
+
+      expect(typeof newItems[0].id).toEqual("string");
+      expect(
+        instructions[0].type === "INSERT" && typeof instructions[0].item.id
+      ).toEqual("string");
+    });
+
+    it("returns values with numeric IDs when given an array with numeric IDs", () => {
+      const { items: newItems, instructions } = reorder(
+        [{ ...items[0], id: 123 }],
+        {
+          type: "INSERT",
+          item: { ...newItem, id: 345 },
+          order: 1,
+        }
+      );
+      console.log(instructions);
+
+      expect(typeof newItems[0].id).toEqual("number");
+      expect(
+        instructions[0].type === "INSERT" && typeof instructions[0].item.id
+      ).toEqual("number");
+    });
+  });
 });
 
 describe("Operations on items with 'column' property", () => {

--- a/src/reorder.test.ts
+++ b/src/reorder.test.ts
@@ -506,6 +506,17 @@ describe("Operations on items without 'column' property", () => {
       expect(instructions).toStrictEqual([]);
     });
 
+    test("Does nothing if an item's order is the same as it's target order", () => {
+      const { items: newItems, instructions } = reorder(items, {
+        type: "MOVE",
+        id: itemA.id,
+        toOrder: itemA.order,
+      });
+
+      expect(newItems).toStrictEqual(items);
+      expect(instructions).toStrictEqual([]);
+    });
+
     test("Moves items from top to bottom", () => {
       const { items: newItems, instructions } = reorder(items, {
         type: "MOVE",
@@ -633,7 +644,6 @@ describe("Operations on items without 'column' property", () => {
           id: itemA.id,
           order: 1,
         },
-
         {
           type: "UPDATE",
           id: itemB.id,
@@ -643,6 +653,72 @@ describe("Operations on items without 'column' property", () => {
           type: "UPDATE",
           id: itemC.id,
           order: 0,
+        },
+      ];
+
+      expect(orderById(instructions)).toStrictEqual(
+        orderById(expectedInstructions)
+      );
+    });
+
+    it("Moves items from top to middle of array", () => {
+      const { items: newItems, instructions } = reorder(items, {
+        type: "MOVE",
+        id: itemA.id,
+        toOrder: 1,
+      });
+
+      expect(orderById(newItems)).toStrictEqual(
+        orderById([
+          { ...itemA, order: 1 },
+          { ...itemB, order: 0 },
+          { ...itemC, order: 2 },
+        ])
+      );
+
+      const expectedInstructions: Instructions = [
+        {
+          type: "UPDATE",
+          id: itemA.id,
+          order: 1,
+        },
+        {
+          type: "UPDATE",
+          id: itemB.id,
+          order: 0,
+        },
+      ];
+
+      expect(orderById(instructions)).toStrictEqual(
+        orderById(expectedInstructions)
+      );
+    });
+
+    it("Moves items from bottom to middle of array", () => {
+      const { items: newItems, instructions } = reorder(items, {
+        type: "MOVE",
+        id: itemC.id,
+        toOrder: 1,
+      });
+
+      expect(orderById(newItems)).toStrictEqual(
+        orderById([
+          { ...itemA, order: 0 },
+          { ...itemB, order: 2 },
+          { ...itemC, order: 1 },
+        ])
+      );
+
+      const expectedInstructions: Instructions = [
+        {
+          type: "UPDATE",
+          id: itemB.id,
+          order: 2,
+        },
+        {
+          type: "UPDATE",
+          id: itemC.id,
+          order: 1,
         },
       ];
 

--- a/src/reorder.ts
+++ b/src/reorder.ts
@@ -5,9 +5,13 @@ import {
   Action,
   Instruction,
   Instructions,
+  ID,
 } from "./reorder.types";
 
-function clampOrder(items: OrderedItem[], order: number): number {
+function clampOrder<T extends ID>(
+  items: OrderedItem<T>[],
+  order: number
+): number {
   let newOrder = order;
   if (newOrder < 0) {
     newOrder = 0;
@@ -17,11 +21,11 @@ function clampOrder(items: OrderedItem[], order: number): number {
   return newOrder;
 }
 
-function insertItem(
-  items: OrderedItem[],
-  action: InsertAction
-): { items: OrderedItem[]; instructions: Instructions } {
-  let instructions: Instruction[] = [];
+function insertItem<T extends ID>(
+  items: OrderedItem<T>[],
+  action: InsertAction<T>
+): { items: OrderedItem<T>[]; instructions: Instructions<T> } {
+  let instructions: Instruction<T>[] = [];
 
   let newOrder = clampOrder(items, action.order);
 
@@ -35,7 +39,7 @@ function insertItem(
         order: item.order + 1,
       };
 
-      let instruction: Instruction = {
+      let instruction: Instruction<T> = {
         type: "UPDATE",
         id: bumpedItem.id,
         order: bumpedItem.order,
@@ -48,7 +52,7 @@ function insertItem(
     return item;
   });
 
-  let newItem: OrderedItem = {
+  let newItem: OrderedItem<T> = {
     ...action.item,
     order: newOrder,
   };
@@ -57,7 +61,7 @@ function insertItem(
     newItem.column = action.column;
   }
 
-  let instruction: Instruction = {
+  let instruction: Instruction<T> = {
     type: "INSERT",
     item: newItem,
   };
@@ -69,11 +73,11 @@ function insertItem(
   return { items: newItems, instructions };
 }
 
-function removeItem(
-  items: OrderedItem[],
-  action: RemoveAction
-): { items: OrderedItem[]; instructions: Instructions } {
-  let instructions: Instruction[] = [];
+function removeItem<T extends ID>(
+  items: OrderedItem<T>[],
+  action: RemoveAction<T>
+): { items: OrderedItem<T>[]; instructions: Instructions<T> } {
+  let instructions: Instruction<T>[] = [];
   let newItems = [...items];
 
   const removedItem = items.find((item) => item.id === action.id);
@@ -116,11 +120,11 @@ function removeItem(
 /**
  * Performs an action (insert, remove, move) on the items.
  */
-export function reorder(
-  items: OrderedItem[],
-  action: Action
-): { items: OrderedItem[]; instructions: Instructions } {
-  let allInstructions: Instructions = [];
+export function reorder<T extends ID>(
+  items: OrderedItem<T>[],
+  action: Action<T>
+): { items: OrderedItem<T>[]; instructions: Instructions<T> } {
+  let allInstructions: Instructions<T> = [];
   let newItems = [...items];
 
   // If INSERT, bump the indices in same columns (if after inserted order)
@@ -176,7 +180,7 @@ export function reorder(
         (instruction) => instruction.type === "INSERT"
       );
       if (insertInstruction.type === "INSERT") {
-        let moveInstruction: Instruction = {
+        let moveInstruction: Instruction<T> = {
           type: "UPDATE",
           id: movedItem.id,
           order: insertInstruction.item.order,

--- a/src/reorder.ts
+++ b/src/reorder.ts
@@ -120,7 +120,9 @@ function moveItem<T extends ID>(
   const instructions: UpdateInstruction<T>[] = [];
 
   const movedItem = items.find((item) => item.id === action.id);
-  if (movedItem) {
+  const movedItemIsActuallyMoving = movedItem?.order !== action.toOrder;
+
+  if (movedItem && movedItemIsActuallyMoving) {
     const direction = action.toOrder > movedItem.order ? "DOWN" : "UP";
     if (direction === "DOWN") {
       newItems = newItems.map((item) => {

--- a/src/reorder.ts
+++ b/src/reorder.ts
@@ -3,20 +3,20 @@ import {
   InsertAction,
   RemoveAction,
   Action,
-  Instruction,
   Instructions,
   ID,
+  MoveAction,
+  UpdateInstruction,
+  RemoveInstruction,
+  InsertInstruction,
 } from "./reorder.types";
 
-function clampOrder<T extends ID>(
-  items: OrderedItem<T>[],
-  order: number
-): number {
+function clampOrder<T extends ID>(itemCount: number, order: number): number {
   let newOrder = order;
   if (newOrder < 0) {
     newOrder = 0;
-  } else if (newOrder > items.length + 1) {
-    newOrder = items.length;
+  } else if (newOrder > itemCount - 1) {
+    newOrder = itemCount - 1;
   }
   return newOrder;
 }
@@ -24,22 +24,23 @@ function clampOrder<T extends ID>(
 function insertItem<T extends ID>(
   items: OrderedItem<T>[],
   action: InsertAction<T>
-): { items: OrderedItem<T>[]; instructions: Instructions<T> } {
-  let instructions: Instruction<T>[] = [];
+): {
+  items: OrderedItem<T>[];
+  instructions: (InsertInstruction<T> | UpdateInstruction<T>)[];
+} {
+  let instructions: (InsertInstruction<T> | UpdateInstruction<T>)[] = [];
 
-  let newOrder = clampOrder(items, action.order);
+  const itemCountAfterInsert = items.length + 1;
+  let newOrder = clampOrder(itemCountAfterInsert, action.order);
 
   let newItems = [...items].map(function bumpAndCreateUpdateInstruction(item) {
-    const itemIsInColumn =
-      typeof action.column === "number" ? item.column === action.column : true;
-
-    if (itemIsInColumn && item.order >= action.order) {
+    if (item.order >= action.order) {
       const bumpedItem = {
         ...item,
         order: item.order + 1,
       };
 
-      let instruction: Instruction<T> = {
+      let instruction: UpdateInstruction<T> = {
         type: "UPDATE",
         id: bumpedItem.id,
         order: bumpedItem.order,
@@ -57,11 +58,7 @@ function insertItem<T extends ID>(
     order: newOrder,
   };
 
-  if (typeof action.column === "number") {
-    newItem.column = action.column;
-  }
-
-  let instruction: Instruction<T> = {
+  let instruction: InsertInstruction<T> = {
     type: "INSERT",
     item: newItem,
   };
@@ -76,8 +73,11 @@ function insertItem<T extends ID>(
 function removeItem<T extends ID>(
   items: OrderedItem<T>[],
   action: RemoveAction<T>
-): { items: OrderedItem<T>[]; instructions: Instructions<T> } {
-  let instructions: Instruction<T>[] = [];
+): {
+  items: OrderedItem<T>[];
+  instructions: (RemoveInstruction<T> | UpdateInstruction<T>)[];
+} {
+  let instructions: (RemoveInstruction<T> | UpdateInstruction<T>)[] = [];
   let newItems = [...items];
 
   const removedItem = items.find((item) => item.id === action.id);
@@ -91,12 +91,7 @@ function removeItem<T extends ID>(
     newItems = newItems
       .filter((item) => item.id !== action.id)
       .map(function reduceAndCreateUpdateInstruction(item) {
-        const itemIsInColumn =
-          typeof removedItem.column === "number"
-            ? item.column === removedItem.column
-            : true;
-
-        if (itemIsInColumn && item.order > removedItem.order) {
+        if (item.order > removedItem.order) {
           let reducedItem = {
             ...item,
             order: item.order - 1,
@@ -117,6 +112,59 @@ function removeItem<T extends ID>(
   return { items: newItems, instructions };
 }
 
+function moveItem<T extends ID>(
+  items: OrderedItem<T>[],
+  action: MoveAction<T>
+): { items: OrderedItem<T>[]; instructions: UpdateInstruction<T>[] } {
+  // Algo:
+  // - Moved item leaves a hole
+  // - Destination needs space
+  // Items between source-destination indices are affected
+  //
+  // If moving up, bump every item between (destination <=> source)
+  // If moving down, reduce every item between (source <=> destination)
+
+  let newItems = [...items];
+  const instructions: UpdateInstruction<T>[] = [];
+
+  const movedItem = items.find((item) => item.id === action.id);
+  console.log(action, movedItem);
+  if (movedItem) {
+    const direction = action.toOrder > movedItem.order ? "DOWN" : "UP";
+    if (direction === "DOWN") {
+      newItems = newItems.map((item) => {
+        if (item.order <= action.toOrder && item.order > movedItem.order) {
+          const newOrder = item.order - 1;
+          instructions.push({ type: "UPDATE", id: item.id, order: newOrder });
+          return { ...item, order: newOrder };
+        }
+        if (item.id === action.id) {
+          const newOrder = clampOrder(items.length, action.toOrder);
+          instructions.push({ type: "UPDATE", id: item.id, order: newOrder });
+          return { ...item, order: newOrder };
+        }
+        return item;
+      });
+    } else {
+      newItems = newItems.map((item) => {
+        if (item.order < movedItem.order && item.order >= action.toOrder) {
+          const newOrder = item.order + 1;
+          instructions.push({ type: "UPDATE", id: item.id, order: newOrder });
+          return { ...item, order: newOrder };
+        }
+        if (item.id === action.id) {
+          const newOrder = clampOrder(items.length, action.toOrder);
+          instructions.push({ type: "UPDATE", id: item.id, order: newOrder });
+          return { ...item, order: clampOrder(items.length, action.toOrder) };
+        }
+        return item;
+      });
+    }
+  }
+
+  return { items: newItems, instructions };
+}
+
 /**
  * Performs an action (insert, remove, move) on the items.
  */
@@ -124,74 +172,12 @@ export function reorder<T extends ID>(
   items: OrderedItem<T>[],
   action: Action<T>
 ): { items: OrderedItem<T>[]; instructions: Instructions<T> } {
-  let allInstructions: Instructions<T> = [];
-  let newItems = [...items];
-
-  // If INSERT, bump the indices in same columns (if after inserted order)
-  if (action.type === "INSERT") {
-    let { items: insertResult, instructions } = insertItem(items, action);
-    newItems = insertResult;
-    allInstructions = [...allInstructions, ...instructions];
+  switch (action.type) {
+    case "INSERT":
+      return insertItem(items, action);
+    case "REMOVE":
+      return removeItem(items, action);
+    case "MOVE":
+      return moveItem(items, action);
   }
-  // If REMOVE, reduce the indices in same column (if after removed order)
-  else if (action.type === "REMOVE") {
-    let { items: removeResult, instructions } = removeItem(items, action);
-    newItems = removeResult;
-    allInstructions = [...allInstructions, ...instructions];
-  }
-
-  // If MOVE, first do a REMOVE, then an INSERT
-  else if (action.type === "MOVE") {
-    const movedItem = items.find(function findMovedItem(item) {
-      return item.id === action.id;
-    });
-
-    if (movedItem) {
-      let {
-        items: removeResult,
-        instructions: removeInstructions,
-      } = removeItem(items, {
-        type: "REMOVE",
-        id: action.id,
-      });
-      allInstructions = [...allInstructions, ...removeInstructions];
-
-      let {
-        items: insertResult,
-        instructions: insertInstructions,
-      } = insertItem(removeResult, {
-        type: "INSERT",
-        order: action.toOrder,
-        column: action.toColumn,
-        item: movedItem,
-      });
-
-      newItems = insertResult;
-      allInstructions = [...allInstructions, ...insertInstructions];
-
-      // The INSERT and REMOVE operations above result in
-      // 2 separate instructions. We actually only want
-      // 1 instruction — an UPDATE one. So, we remove those
-      // instructions and insert a new one.
-      allInstructions = allInstructions.filter(
-        (instruction) => instruction.type === "UPDATE"
-      );
-      const insertInstruction = insertInstructions.find(
-        (instruction) => instruction.type === "INSERT"
-      );
-      if (insertInstruction.type === "INSERT") {
-        let moveInstruction: Instruction<T> = {
-          type: "UPDATE",
-          id: movedItem.id,
-          order: insertInstruction.item.order,
-        };
-        if (typeof insertInstruction.item.column === "number") {
-          moveInstruction.column = insertInstruction.item.column;
-        }
-        allInstructions.push(moveInstruction);
-      }
-    }
-  }
-
-  return { items: newItems, instructions: allInstructions };
 }

--- a/src/reorder.ts
+++ b/src/reorder.ts
@@ -116,19 +116,10 @@ function moveItem<T extends ID>(
   items: OrderedItem<T>[],
   action: MoveAction<T>
 ): { items: OrderedItem<T>[]; instructions: UpdateInstruction<T>[] } {
-  // Algo:
-  // - Moved item leaves a hole
-  // - Destination needs space
-  // Items between source-destination indices are affected
-  //
-  // If moving up, bump every item between (destination <=> source)
-  // If moving down, reduce every item between (source <=> destination)
-
   let newItems = [...items];
   const instructions: UpdateInstruction<T>[] = [];
 
   const movedItem = items.find((item) => item.id === action.id);
-  console.log(action, movedItem);
   if (movedItem) {
     const direction = action.toOrder > movedItem.order ? "DOWN" : "UP";
     if (direction === "DOWN") {
@@ -138,6 +129,7 @@ function moveItem<T extends ID>(
           instructions.push({ type: "UPDATE", id: item.id, order: newOrder });
           return { ...item, order: newOrder };
         }
+
         if (item.id === action.id) {
           const newOrder = clampOrder(items.length, action.toOrder);
           instructions.push({ type: "UPDATE", id: item.id, order: newOrder });
@@ -152,10 +144,11 @@ function moveItem<T extends ID>(
           instructions.push({ type: "UPDATE", id: item.id, order: newOrder });
           return { ...item, order: newOrder };
         }
+
         if (item.id === action.id) {
           const newOrder = clampOrder(items.length, action.toOrder);
           instructions.push({ type: "UPDATE", id: item.id, order: newOrder });
-          return { ...item, order: clampOrder(items.length, action.toOrder) };
+          return { ...item, order: newOrder };
         }
         return item;
       });

--- a/src/reorder.types.ts
+++ b/src/reorder.types.ts
@@ -1,13 +1,13 @@
 export type ID = string | number;
 
-export type OrderedItem<T extends ID> = {
+export type OrderedItem<T extends ID = string> = {
   id: T;
   order: number;
   column?: number;
   [x: string]: any;
 };
 
-export type IdItem<T extends ID> = {
+export type IdItem<T extends ID = string> = {
   id: T;
   [x: string]: any;
 };
@@ -53,9 +53,9 @@ export type RemoveInstruction<T extends ID> = {
   id: T;
 };
 
-export type Instruction<T extends ID> =
+export type Instruction<T extends ID = string> =
   | InsertInstruction<T>
   | UpdateInstruction<T>
   | RemoveInstruction<T>;
 
-export type Instructions<T extends ID> = Instruction<T>[];
+export type Instructions<T extends ID = string> = Instruction<T>[];

--- a/src/reorder.types.ts
+++ b/src/reorder.types.ts
@@ -3,7 +3,6 @@ export type ID = string | number;
 export type OrderedItem<T extends ID = string> = {
   id: T;
   order: number;
-  column?: number;
   [x: string]: any;
 };
 
@@ -16,7 +15,6 @@ export type InsertAction<T extends ID> = {
   type: "INSERT";
   item: IdItem<T>;
   order: number;
-  column?: number;
 };
 
 export type RemoveAction<T extends ID> = {
@@ -28,7 +26,6 @@ export type MoveAction<T extends ID> = {
   type: "MOVE";
   id: T;
   toOrder: number;
-  toColumn?: number;
 };
 
 export type Action<T extends ID> =
@@ -45,7 +42,6 @@ export type UpdateInstruction<T extends ID> = {
   type: "UPDATE";
   id: T;
   order: number;
-  column?: number;
 };
 
 export type RemoveInstruction<T extends ID> = {

--- a/src/reorder.types.ts
+++ b/src/reorder.types.ts
@@ -1,58 +1,61 @@
-export type ID = string;
+export type ID = string | number;
 
-export type OrderedItem = {
-  id: ID;
+export type OrderedItem<T extends ID> = {
+  id: T;
   order: number;
   column?: number;
   [x: string]: any;
 };
 
-export type IdItem = {
-  id: ID;
+export type IdItem<T extends ID> = {
+  id: T;
   [x: string]: any;
 };
 
-export type InsertAction = {
+export type InsertAction<T extends ID> = {
   type: "INSERT";
-  item: IdItem;
+  item: IdItem<T>;
   order: number;
   column?: number;
 };
 
-export type RemoveAction = {
+export type RemoveAction<T extends ID> = {
   type: "REMOVE";
-  id: ID;
+  id: T;
 };
 
-export type MoveAction = {
+export type MoveAction<T extends ID> = {
   type: "MOVE";
-  id: ID;
+  id: T;
   toOrder: number;
   toColumn?: number;
 };
 
-export type Action = InsertAction | RemoveAction | MoveAction;
+export type Action<T extends ID> =
+  | InsertAction<T>
+  | RemoveAction<T>
+  | MoveAction<T>;
 
-export type InsertInstruction = {
+export type InsertInstruction<T extends ID> = {
   type: "INSERT";
-  item: OrderedItem;
+  item: OrderedItem<T>;
 };
 
-export type UpdateInstruction = {
+export type UpdateInstruction<T extends ID> = {
   type: "UPDATE";
-  id: ID;
+  id: T;
   order: number;
   column?: number;
 };
 
-export type RemoveInstruction = {
+export type RemoveInstruction<T extends ID> = {
   type: "REMOVE";
-  id: ID;
+  id: T;
 };
 
-export type Instruction =
-  | InsertInstruction
-  | UpdateInstruction
-  | RemoveInstruction;
+export type Instruction<T extends ID> =
+  | InsertInstruction<T>
+  | UpdateInstruction<T>
+  | RemoveInstruction<T>;
 
-export type Instructions = Instruction[];
+export type Instructions<T extends ID> = Instruction<T>[];


### PR DESCRIPTION
Enables you to pass in objects with both string and number IDs. The returned object uses the same type for their IDs.

This is useful when your IDs are sometimes strings (GraphQL) and sometimes numbers (SQL).a

- [x] Add generic types
- [x] Add type tests for all operations (INSERT, UPDATE, REMOVE)
- [x] Bump version